### PR TITLE
Query params can now be passed for config

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1,25 +1,26 @@
-const ui = require('ui.js');
-const gapiClient = require('gapiClient.js');
-const template = require('template.js');
+const Story = require('story.js');
 
-const spreadsheetId = '1tTyJECAoiLjHQh9_RWtVavhO_rLk133dt8-5c6lN-F0';
+const exampleSpreadsheetId = '1tTyJECAoiLjHQh9_RWtVavhO_rLk133dt8-5c6lN-F0';
 
 function initalize() {
-  gapiClient.getSpreadsheetData(spreadsheetId).then(response => {
-    let templateData = { images: [] };
-    response.entry.forEach(e => {
-      templateData.images.push({
-        path: e.gsx$sceneimageurl.$t,
-        text: e.gsx$bodytext.$t
-      });
-    });
+  const qs = getQueryParams(window.location.search);
+  qs.source = qs.hasOwnProperty('source') ? qs.source : exampleSpreadsheetId;
 
-    let scene = template.buildTemplate(templateData);
-    document.querySelector('body').appendChild(scene);
-    ui.addEventListeners();
-  }, response => {
-    console.log(response.result.error.message);
-  });
+  let s = new Story(qs);
+}
+
+function getQueryParams(qs) {
+  qs = qs.split("+").join(" ");
+
+  var params = {}, tokens,
+  re = /[?&]?([^=]+)=([^&]*)/g;
+
+  while (tokens = re.exec(qs)) {
+    params[decodeURIComponent(tokens[1])]
+    = decodeURIComponent(tokens[2]);
+  }
+
+  return params;
 }
 
 window.onload = initalize;

--- a/src/js/story.js
+++ b/src/js/story.js
@@ -1,0 +1,30 @@
+const ui = require('ui.js');
+const gapiClient = require('gapiClient.js');
+const template = require('template.js');
+
+module.exports = class Story {
+  constructor(config) {
+    this.config = config;
+
+    this.buildScene().then(() => {
+      document.querySelector('body').appendChild(this.scene);
+      ui.addEventListeners();
+    });
+  }
+
+  buildScene() {
+    return gapiClient.getSpreadsheetData(this.config.source).then(response => {
+      let templateData = { images: [] };
+      response.entry.forEach(e => {
+        templateData.images.push({
+          path: e.gsx$sceneimageurl.$t,
+          text: e.gsx$bodytext.$t
+        });
+      });
+
+      this.scene = template.buildTemplate(templateData);
+    }, response => {
+      console.log(response.result.error.message);
+    });
+  }
+}


### PR DESCRIPTION
Similar to TimelineJS, we can now pass query parameters. 

For example, this url: `http://localhost:8080/?source=1tTyJECAoiLjHQh9_RWtVavhO_rLk133dt8-5c6lN-F0` specifies the source spreadsheet ID.

I've also created a class called Story. We can change the name in the future, but this pattern is probably better for organization.