### PR TITLE
Request images with crossorigin attribute set to anonymous

### DIFF
--- a/src/js/data/template.js
+++ b/src/js/data/template.js
@@ -74,6 +74,7 @@ module.exports = {
         templateData.images.forEach((img, i) => {
             let skyEl = dom.createElement('img', `sky-${i}`, ['sky']);
             skyEl.setAttribute('src', img.path);
+            skyEl.setAttribute('crossorigin', 'anonymous');
             assets.appendChild(skyEl);
 
             let thumbnailEl = dom.createElement('img', `thumbnail-${i}`, ['thumbnail', `${i === 0 ? 'selected-thumbnail' : ''}`]);


### PR DESCRIPTION
fixes these warnings
![screen shot 2017-03-30 at 2 40 03 pm](https://cloud.githubusercontent.com/assets/8320987/24522973/093cee80-1557-11e7-83ca-803c23fb400e.png)
