### PR TITLE
Resolved safari bugs

### DIFF
--- a/src/js/ui/ui.js
+++ b/src/js/ui/ui.js
@@ -32,28 +32,10 @@ module.exports = class UI {
     // show loading screen until assets are loaded
     aAssetsEl.addEventListener('loaded', () => {
       const loadingScreen = document.getElementById('loading');
-      let fadeOut = () => {
-        return loadingScreen.animate({ opacity: [1, 0] }, {
-          duration: 500,
-          easing: 'ease-in',
-          fill: 'forwards'
-        });
-      }
-
       const scenes = document.getElementById('rendered-template');
-      let fadeIn = () => {
-        return scenes.animate({ opacity: [0, 1] }, {
-          duration: 500,
-          easing: 'ease-out',
-          fill: 'forwards'
-        });
-      }
 
-      // fade out the loading screen and then fade into the scenes
-      fadeOut().onfinish = () => {
-        loadingScreen.remove();
-        fadeIn();
-      }
+      loadingScreen.classList.add('fade-out');
+      setTimeout(() => scenes.classList.add('fade-in'), 500);
 
       // update skybox in case the projection needs to be fixed
       this._updateSkybox();

--- a/src/scss/scene.scss
+++ b/src/scss/scene.scss
@@ -232,3 +232,37 @@ body.modal {
     justify-content : center;
     align-items     : center;
 }
+
+.fade-in {
+    animation: 0.5s 1 forwards fadeIn;
+    -webkit-animation: 0.5s 1 forwards fadeIn;
+}
+
+.fade-out {
+    animation: 0.5s 1 forwards fadeOut;
+    -webkit-animation: 0.5s 1 forwards fadeOut;
+}
+
+@keyframes fadeIn {
+    from { opacity: 0; }
+
+    to { opacity: 1; }
+}
+
+@-webkit-keyframes fadeIn {
+    from { opacity: 0; }
+
+    to { opacity: 1; }
+}
+
+@keyframes fadeOut {
+    from { opacity: 1; }
+
+    to { opacity: 0; }
+}
+
+@-webkit-keyframes fadeOut {
+    from { opacity: 1; }
+
+    to { opacity: 0; }
+}


### PR DESCRIPTION
Animations on perspective don't work in safari if the parent container has a `background-color`, details here:
* https://stackoverflow.com/questions/40865842/transformed-child-clipped-by-parent-background-in-safari-irrespective-of-z-inde#
* https://bugs.webkit.org/show_bug.cgi?id=88587

[Web Animations API isn't supported by safari yet, so we have to use CSS animations](https://developer.mozilla.org/en-US/docs/Web/API/Web_Animations_API)